### PR TITLE
README - requirements for installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ $ go get github.com/mongoeye/mongoeye
 $ cd $GOPATH/src/github.com/mongoeye/mongoeye
 $ make
 ```
+### Requirements
+* go1.8
+* richgo [https://github.com/kyoh86/richgo](https://github.com/kyoh86/richgo)
+* lint [https://github.com/golang/lint](https://github.com/golang/lint)
 
 ## Usage
 


### PR DESCRIPTION
This could be very useful for people new to golang.

At least it would have saved me some time when trying to make it run: standard version installed on Ubuntu (16.10) seems to be go1.6 which gives compiler errors (type reflect.StructTag has no field or method Lookup) about statements that were included in go1.7 [it seems](https://github.com/golang/go/issues/14883). 
Another notice could be: always newest go version.